### PR TITLE
Fix no suitable reader found for YubiKey 5 NFC on macOS Catalina

### DIFF
--- a/ykoath.go
+++ b/ykoath.go
@@ -57,7 +57,7 @@ func New() (*OATH, error) {
 
 	for _, reader := range readers {
 
-		if strings.Contains(reader, "Yubikey") {
+		if strings.Contains(strings.ToLower(reader), "yubikey") {
 
 			card, err := context.Connect(reader, scard.ShareShared, scard.ProtocolAny)
 


### PR DESCRIPTION
YubiKey: YubiKey 5 NFC
OS: macOS Catalina (10.15)

My YubiKey device name is `YubiKey OTP+FIDO+CCID` which does not contain the string `Yubikey `
```
$ ioreg -p IOUSB
+-o Root  <class IORegistryEntry, id 0x100000100, retain 20>
  +-o AppleUSBXHCI Root Hub Simulation@14000000  <class AppleUSBRootHubDevice, id 0x100000336, registered, matched, active, busy 0 (0 ms), retai$
    +-o USB 2.0 BILLBOARD             @14200000  <class AppleUSBDevice, id 0x100000355, registered, matched, active, busy 0 (0 ms), retain 12>
    +-o FaceTime HD Camera (Built-in)@14600000  <class AppleUSBDevice, id 0x100014a68, registered, matched, active, busy 0 (1 ms), retain 17>
    +-o YubiKey OTP+FIDO+CCID@14100000  <class AppleUSBDevice, id 0x10001b6e2, registered, matched, active, busy 0 (1 ms), retain 17>
```