### PR TITLE
fixing bug with New function

### DIFF
--- a/ykoath.go
+++ b/ykoath.go
@@ -45,7 +45,7 @@ const (
 
 // New initializes a new OATH session
 func New() (*OATH, error) {
-	return NewFromSerial("")
+	return NewFromSerialList([]string{})
 }
 
 // NewFromSerial creates an OATH session for a specific key


### PR DESCRIPTION
to @yawn 
cc @paulbramsen

## Background

The `ykoath.New()` function is intended to return the first yubikey, but in v1.0.5 a bug was introduced that breaks this:

```
Error: no suitable reader found (out of 1 readers)
```

## Changes

The `NewFromSerialList` checks to see a array of any serials was provided, and is intended to return the first yubikey in the event that [no serials are provided](https://github.com/ryandeivert/ykoath/blob/c50b68f272924fa1828b133111109d47046bc028/ykoath.go#L65-L67). However, that fails because the `New()` function always sends an empty string ("") as the serial.

This change calls the `NewFromSerialList` with an empty array, ensuring the first yubikey entry is returned to the caller.

This reverts the back to what existed in <v1.0.4.

